### PR TITLE
Update NaxRISCV Bios to enable mstatus.MIE interrupts

### DIFF
--- a/litex/soc/cores/cpu/naxriscv/crt0.S
+++ b/litex/soc/cores/cpu/naxriscv/crt0.S
@@ -124,8 +124,7 @@ bss_loop:
 bss_done:
 
   call plic_init // initialize external interrupt controller
-  li t0, 0x800   // external interrupt sources only (using LiteX timer);
-                 // NOTE: must still enable mstatus.MIE!
+  li t0, 0x808   // external interrupt sources (using LiteX timer) and enable mstatus.MIE.
   csrw mie,t0
 
   call main


### PR DESCRIPTION
NaxRISCV had an issue where running the demo program would not work without mstatus.MIE being enabled during BIOS.

Added a very small fix in crt0.S to stop this issue as per #2169.